### PR TITLE
protected routes


### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
             exact
             path="/logout"
             element={
-              <ProtectedRoute redirectPath="/">
+              <ProtectedRoute redirectPath="/" roles={['admin']}>
                 <Logout />
               </ProtectedRoute>
             }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,14 @@ function App() {
           <Route
             exact
             path="/logout"
-            element={<ProtectedRoute Component={Logout} redirectPath="/" roles={['admin']} />}
+            element={
+              <ProtectedRoute Component={Logout} redirectPath="/" roles={['admin', 'General']} />
+            }
+          />
+          <Route
+            exact
+            path="admin"
+            element={<ProtectedRoute Component={Logout} redirectPath="/logout" roles={['admin']} />}
           />
           <Route exact path="/register" element={<Register />} />
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,11 +17,7 @@ function App() {
           <Route
             exact
             path="/logout"
-            element={
-              <ProtectedRoute redirectPath="/" roles={['admin']}>
-                <Logout />
-              </ProtectedRoute>
-            }
+            element={<ProtectedRoute Component={Logout} redirectPath="/" roles={['admin']} />}
           />
           <Route exact path="/register" element={<Register />} />
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Register from './components/register/register';
 
 import Login from './components/Login';
 import Logout from './components/Logout';
+import ProtectedRoute from './utils/ProtectedRoute';
 
 function App() {
   return (
@@ -13,7 +14,15 @@ function App() {
       <Router>
         <Routes>
           <Route exact path="/" element={<Login />} />
-          <Route exact path="/logout" element={<Logout />} />
+          <Route
+            exact
+            path="/logout"
+            element={
+              <ProtectedRoute redirectPath="/">
+                <Logout />
+              </ProtectedRoute>
+            }
+          />
           <Route exact path="/register" element={<Register />} />
         </Routes>
       </Router>

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { PropTypes } from 'prop-types';
+
+import { auth } from './auth_utils';
+import { withCookies } from './cookie_utils';
+
+// TODO: Make calls to backend to verify user access token
+// const verifyToken = () => {
+//   return true;
+// };
+
+/**
+ * Protects a route from unauthenticated users
+ * @param {Component} children The component thre user is trying to access
+ * @param {Cookies} cookies The user's current cookies
+ * @param {string} redirectPath The path to redirect the user to if they're not logged in
+ * @returns The relevant path to redirect the user to dependending on authentication state.
+ */
+const ProtectedRoute = ({ children, redirectPath }) => {
+  if (auth.currentUser) {
+    // TODO: Get user roles from cookies for additional verification
+    return children;
+  }
+  return <Navigate to={redirectPath} />;
+};
+
+ProtectedRoute.propTypes = {
+  children: PropTypes.elementType.isRequired,
+  redirectPath: PropTypes.string.isRequired,
+};
+
+export default withCookies(ProtectedRoute);

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -3,25 +3,13 @@ import { Navigate } from 'react-router-dom';
 import { PropTypes, instanceOf } from 'prop-types';
 
 import { withCookies, cookieKeys, Cookies } from './cookie_utils';
-import { auth } from './auth_utils';
+import { auth, getCurrentUser } from './auth_utils';
 
 // TODO: Make calls to backend to verify user access token
 // const verifyToken = () => {
 //   return true;
 // };
 
-/**
- * Returns the current user synchronously
- * @param {Auth} authInstance
- * @returns The current user (or undefined)
- */
-const getCurrentUser = authInstance =>
-  new Promise((resolve, reject) => {
-    const unsubscribe = authInstance.onAuthStateChanged(user => {
-      unsubscribe();
-      resolve(user);
-    }, reject);
-  });
 /**
  * Protects a route from unauthenticated users
  * @param {Component} children The component the user is trying to access
@@ -33,7 +21,6 @@ const getCurrentUser = authInstance =>
 const ProtectedRoute = ({ children, redirectPath, roles, cookies }) => {
   const currentUser = getCurrentUser(auth);
   if (currentUser && roles.includes(cookies.get(cookieKeys.ROLE))) {
-    // console.log(roles.includes(cookies.get(cookieKeys.ROLE)));
     return children;
   }
   return <Navigate to={redirectPath} />;

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -18,16 +18,16 @@ import { auth, getCurrentUser } from './auth_utils';
  * @param {Cookies} cookies The user's current cookies
  * @returns The relevant path to redirect the user to dependending on authentication state.
  */
-const ProtectedRoute = ({ children, redirectPath, roles, cookies }) => {
+const ProtectedRoute = ({ Component, redirectPath, roles, cookies }) => {
   const currentUser = getCurrentUser(auth);
   if (currentUser && roles.includes(cookies.get(cookieKeys.ROLE))) {
-    return children;
+    return <Component />;
   }
   return <Navigate to={redirectPath} />;
 };
 
 ProtectedRoute.propTypes = {
-  children: PropTypes.element.isRequired,
+  Component: PropTypes.elementType.isRequired,
   redirectPath: PropTypes.string.isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
   cookies: instanceOf(Cookies).isRequired,

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -11,15 +11,29 @@ import { auth } from './auth_utils';
 // };
 
 /**
+ * Returns the current user synchronously
+ * @param {Auth} authInstance
+ * @returns The current user (or undefined)
+ */
+const getCurrentUser = authInstance =>
+  new Promise((resolve, reject) => {
+    const unsubscribe = authInstance.onAuthStateChanged(user => {
+      unsubscribe();
+      resolve(user);
+    }, reject);
+  });
+/**
  * Protects a route from unauthenticated users
  * @param {Component} children The component the user is trying to access
- * @param {Cookies} cookies The user's current cookies
  * @param {string} redirectPath The path to redirect the user to if they're not logged in
+ * @param {Array} roles A list of roles that are allowed to access the route
+ * @param {Cookies} cookies The user's current cookies
  * @returns The relevant path to redirect the user to dependending on authentication state.
  */
 const ProtectedRoute = ({ children, redirectPath, roles, cookies }) => {
-  if (auth.currentUser && roles.includes(cookies.get(cookieKeys.ROLE))) {
-    // TODO: Get user roles from cookies for additional verification
+  const currentUser = getCurrentUser(auth);
+  if (currentUser && roles.includes(cookies.get(cookieKeys.ROLE))) {
+    // console.log(roles.includes(cookies.get(cookieKeys.ROLE)));
     return children;
   }
   return <Navigate to={redirectPath} />;

--- a/src/utils/ProtectedRoute.jsx
+++ b/src/utils/ProtectedRoute.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { PropTypes } from 'prop-types';
+import { PropTypes, instanceOf } from 'prop-types';
 
+import { withCookies, cookieKeys, Cookies } from './cookie_utils';
 import { auth } from './auth_utils';
-import { withCookies } from './cookie_utils';
 
 // TODO: Make calls to backend to verify user access token
 // const verifyToken = () => {
@@ -12,13 +12,13 @@ import { withCookies } from './cookie_utils';
 
 /**
  * Protects a route from unauthenticated users
- * @param {Component} children The component thre user is trying to access
+ * @param {Component} children The component the user is trying to access
  * @param {Cookies} cookies The user's current cookies
  * @param {string} redirectPath The path to redirect the user to if they're not logged in
  * @returns The relevant path to redirect the user to dependending on authentication state.
  */
-const ProtectedRoute = ({ children, redirectPath }) => {
-  if (auth.currentUser) {
+const ProtectedRoute = ({ children, redirectPath, roles, cookies }) => {
+  if (auth.currentUser && roles.includes(cookies.get(cookieKeys.ROLE))) {
     // TODO: Get user roles from cookies for additional verification
     return children;
   }
@@ -26,8 +26,10 @@ const ProtectedRoute = ({ children, redirectPath }) => {
 };
 
 ProtectedRoute.propTypes = {
-  children: PropTypes.elementType.isRequired,
+  children: PropTypes.element.isRequired,
   redirectPath: PropTypes.string.isRequired,
+  roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+  cookies: instanceOf(Cookies).isRequired,
 };
 
 export default withCookies(ProtectedRoute);

--- a/src/utils/auth_utils.js
+++ b/src/utils/auth_utils.js
@@ -121,6 +121,19 @@ const logout = async (redirectPath, navigate, cookies) => {
   navigate(redirectPath);
 };
 
+/**
+ * Returns the current user synchronously
+ * @param {Auth} authInstance
+ * @returns The current user (or undefined)
+ */
+const getCurrentUser = authInstance =>
+  new Promise((resolve, reject) => {
+    const unsubscribe = authInstance.onAuthStateChanged(user => {
+      unsubscribe();
+      resolve(user);
+    }, reject);
+  });
+
 export {
   auth,
   useNavigate,
@@ -129,4 +142,5 @@ export {
   registerWithEmailAndPassword,
   sendPasswordReset,
   logout,
+  getCurrentUser,
 };

--- a/src/utils/auth_utils.js
+++ b/src/utils/auth_utils.js
@@ -68,14 +68,15 @@ const signInWithGoogle = async (newUserRedirectPath, defaultRedirectPath, naviga
   const provider = new GoogleAuthProvider();
   const userCredential = await signInWithPopup(auth, provider);
   const newUser = getAdditionalUserInfo(userCredential).isNewUser;
+  cookies.set(cookieKeys.ACCESS_TOKEN, auth.currentUser.accessToken, cookieConfig);
   if (newUser) {
     await createUserInDB(auth.currentUser.email, userCredential.user.uid, 'General', true);
+    await addRoleToCookies(cookies);
     navigate(newUserRedirectPath);
   } else {
+    await addRoleToCookies(cookies);
     navigate(defaultRedirectPath);
   }
-  cookies.set(cookieKeys.ACCESS_TOKEN, auth.currentUser.accessToken, cookieConfig);
-  addRoleToCookies(cookies);
 };
 
 /**
@@ -89,9 +90,9 @@ const signInWithGoogle = async (newUserRedirectPath, defaultRedirectPath, naviga
  */
 const logInWithEmailAndPassword = async (email, password, redirectPath, navigate, cookies) => {
   await signInWithEmailAndPassword(auth, email, password);
-  navigate(redirectPath);
   cookies.set(cookieKeys.ACCESS_TOKEN, auth.currentUser.accessToken, cookieConfig);
-  addRoleToCookies(cookies);
+  await addRoleToCookies(cookies);
+  navigate(redirectPath);
 };
 
 const createUserInFirebase = async (email, password) => {


### PR DESCRIPTION
Add a wrapper around `Route` from `react-router-dom` to prevent users who aren't logged in from visiting certain pages. Also add functionality for role based access, but don't worry about implementing user roles (user roles will be stored in cookies).

See the [WMK example](https://github.com/ctc-uci/waymakers-frontend/blob/master/src/components/ProtectedRoute/ProtectedRoute.js) from last year. `verifyToken` will be completed in a later sprint, so just add a dummy function there for now.


closes #9